### PR TITLE
Exchange malloc with calloc

### DIFF
--- a/Base32/MF_Base32Additions.m
+++ b/Base32/MF_Base32Additions.m
@@ -46,7 +46,7 @@
         NSUInteger encodedBlocks = (encodedLength + 7) >> 3;
         NSUInteger expectedDataLength = encodedBlocks * 5;
 
-        decodedBytes = malloc(expectedDataLength);
+        decodedBytes = calloc(expectedDataLength);
         if( decodedBytes != NULL ) {
 
             unsigned char encodedByte1, encodedByte2, encodedByte3, encodedByte4;
@@ -153,7 +153,7 @@
         if( padding > 0 ) encodedBlocks++;
         NSUInteger encodedLength = encodedBlocks * 8;
 
-        encodingBytes = malloc(encodedLength);
+        encodingBytes = calloc(encodedLength);
         if( encodingBytes != NULL ) {
             NSUInteger rawBytesToProcess = dataLength;
             NSUInteger rawBaseIndex = 0;


### PR DESCRIPTION
While this does not seem to be a security issue currently, it would be nice to switch to a more safe function.